### PR TITLE
Insert the contents of README files below the directory listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The file icons are also embedded into the `index.html` file so there is no need 
 
 0. Install apindex
     - Check Quick install or "How do I install it?" section on how to do so
+    - You should also ensure that [python-markdown2](https://github.com/trentm/python-markdown2) is installed, as it is a dependency of apindex
 1. Run `tree -Js > tree.json` from the root of your files
 1. Run `apindex <path to tree.json>`
     - Optional: if your files are meant to be hosted on a different base URL than the generated HTML files, you can specify `-b <base URL>`

--- a/apindex.py
+++ b/apindex.py
@@ -12,6 +12,7 @@
 import argparse
 import base64
 import json
+import markdown2
 import os
 from xml.dom.minidom import parseString
 
@@ -58,6 +59,9 @@ class File():
 
     def isDirectory(self):
         return self.file["type"] == "directory"
+
+    def isReadme(self):
+        return self.file["name"].lower().startswith("readme")
 
     def getIcon(self):
         if self.getFileName() == "..":
@@ -134,6 +138,7 @@ class Directory():
         htmlContent = htmlContent.replace("#TITLE", self.curpath)
         htmlContentDir = ""
         htmlContentFile = ""
+        directoryReadme = ""
 
         # add link to go to previous dir
         back_directory = File({"type": "directory", "name": ".."}, self.baseurl, self.curpath, self.ignoredextension, self.output)
@@ -151,9 +156,16 @@ class Directory():
                     htmlContentDir += file.genHTMLEntry()
                 else:
                     htmlContentFile += file.genHTMLEntry()
+                if file.isReadme():
+                    try:
+                        with open(f"{self.curpath}/{i['name']}","r") as reader:
+                            directoryReadme = f'<div id="readme"><u>{i["name"]}</u>\n{markdown2.markdown(reader.read())}</div><hr>'
+                    except:
+                        pass
 
         htmlContent = htmlContent.replace("#GEN_DIRS", htmlContentDir)
         htmlContent = htmlContent.replace("#GEN_FILES", htmlContentFile)
+        htmlContent = htmlContent.replace("#README",directoryReadme)
 
         with open(self.html_foot, "r") as f:
             htmlContent = htmlContent.replace("#FOOTER", f.read()).replace("#VERSION", VERSION)

--- a/apindex.py
+++ b/apindex.py
@@ -158,8 +158,12 @@ class Directory():
                     htmlContentFile += file.genHTMLEntry()
                 if file.isReadme():
                     try:
+                        readmeExt = i['name'].split(".")
                         with open(f"{self.curpath}/{i['name']}","r") as reader:
-                            directoryReadme += f'<div id="readme"><u>{i["name"]}</u>\n{markdown2.markdown(reader.read())}</div><hr>'
+                            if(readmeExt[-1] == "md"):
+                                directoryReadme += f'<div id="readme"><u>{i["name"]}</u>\n{markdown2.markdown(reader.read())}</div><hr>'
+                            elif(readmeExt[-1] == "txt"):
+                                directoryReadme += f'<div id="readme"><u>{i["name"]}</u>\n<p>{reader.read().replace("\n","<br/>")}</p></div><hr>'
                     except:
                         pass
 

--- a/apindex.py
+++ b/apindex.py
@@ -159,7 +159,7 @@ class Directory():
                 if file.isReadme():
                     try:
                         with open(f"{self.curpath}/{i['name']}","r") as reader:
-                            directoryReadme = f'<div id="readme"><u>{i["name"]}</u>\n{markdown2.markdown(reader.read())}</div><hr>'
+                            directoryReadme += f'<div id="readme"><u>{i["name"]}</u>\n{markdown2.markdown(reader.read())}</div><hr>'
                     except:
                         pass
 

--- a/share/apindex/index.template.html
+++ b/share/apindex/index.template.html
@@ -28,6 +28,7 @@
         #GEN_FILES
     </table>
     <hr>
+    #README
     <span>
         #FOOTER
     </span>

--- a/share/apindex/index.template.html
+++ b/share/apindex/index.template.html
@@ -14,6 +14,9 @@
             overflow: scroll;
             display: block;
         }
+        #readme * {
+            font-size: 16px;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
I have modified the script to insert the contents of any file beginning with "readme" below the directory listing. This does add a dependency, python-markdown2, which will convert the content of these files from Markdown to HTML.

The readme files will only be inserted if apindex is run from the root directory where the files are stored, as apindex otherwise wouldn't be able to read the contents of the readme files. I'm not sure if we should add another parameter where the user can specify where the root directory is, just in case someone decided to generate the site from a different directory. The script would work regardless, though readme files will not be inserted under the directory listing.