### PR TITLE
Remove tree requirement

### DIFF
--- a/apindex.py
+++ b/apindex.py
@@ -124,8 +124,9 @@ class File():
 
 
 class Directory():
-    def __init__(self, directory, baseurl, curpath, ignoredextension, output):
+    def __init__(self, directory, filedir, baseurl, curpath, ignoredextension, output):
         self.directory = directory
+        self.filedir = filedir
         self.baseurl = baseurl
         self.curpath = curpath
         self.ignoredextension = ignoredextension
@@ -163,7 +164,7 @@ class Directory():
                 file = File(i, self.baseurl, self.curpath, self.ignoredextension, self.output)
                 if file.isDirectory():
                     # spawn new class and write those first
-                    subdirectory = Directory(i, f"{self.baseurl}/{i['name']}", f"{self.curpath}/{i['name']}", self.ignoredextension, f"{self.output}/{i['name']}")
+                    subdirectory = Directory(i, self.filedir, f"{self.baseurl}/{i['name']}", f"{self.curpath}/{i['name']}", self.ignoredextension, f"{self.output}/{i['name']}")
                     subdirectory.write()
                     htmlContentDir += file.genHTMLEntry()
                 else:
@@ -171,7 +172,7 @@ class Directory():
                 if file.isReadme():
                     try:
                         readmeExt = i['name'].split(".")
-                        with open(f"{self.curpath}/{i['name']}","r") as reader:
+                        with open(f"{self.filedir}/{self.curpath}/{i['name']}","r") as reader:
                             if(readmeExt[-1] == "md"):
                                 directoryReadme += f'<div id="readme"><u>{i["name"]}</u>{markdown2.markdown(reader.read())}</div><hr>'
                             elif(readmeExt[-1] == "txt"):
@@ -179,6 +180,7 @@ class Directory():
                                 directoryReadme += f'<div id="readme"><u>{i["name"]}</u><p>{txtInsert}</p></div><hr>'
                     except:
                         pass
+
 
         htmlContent = htmlContent.replace("#GEN_DIRS", htmlContentDir)
         htmlContent = htmlContent.replace("#GEN_FILES", htmlContentFile)
@@ -244,7 +246,8 @@ if __name__ == "__main__":
     if args.out:
         output = args.out[0]
 
-    dirtree = traverseDirectory(args.directory[0])
+    filedir = args.directory[0]
+    dirtree = traverseDirectory(filedir)
 
-    rootdir = Directory(dirtree, baseurl, curpath, ignoredextension, output)
+    rootdir = Directory(dirtree, filedir, baseurl, curpath, ignoredextension, output)
     rootdir.write()

--- a/apindex.py
+++ b/apindex.py
@@ -20,6 +20,18 @@ from xml.dom.minidom import parseString
 VERSION = "@CPACK_PACKAGE_VERSION_MAJOR@.@CPACK_PACKAGE_VERSION_MINOR@"
 PREFIX = "@CMAKE_INSTALL_PREFIX@"
 
+def traverseDirectory(path):
+    # this will not make valid json, but it will work for our purposes
+    directoryTree = {}
+    if os.path.isdir(path):
+        directoryTree["name"] = os.path.basename(path)
+        directoryTree["type"] = "directory"
+        directoryTree["contents"] = [traverseDirectory(os.path.join(path,item)) for item in os.listdir(path)]
+    else:
+        directoryTree["name"] = os.path.basename(path)
+        directoryTree["type"] = "file"
+        directoryTree["size"] = os.path.getsize(path)
+    return directoryTree
 
 def parseIconsDescription():
     with open(f"{PREFIX}/share/apindex/icons.xml", "r") as f:
@@ -179,10 +191,10 @@ class Directory():
 
 
 if __name__ == "__main__":
-    description = "apindex - Script that, given `tree -Js`, creates a static HTML directory listing"
+    description = "apindex - Script that creates a static HTML directory listing"
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument("tree",
-                        metavar="<output of `tree -Js`>",
+    parser.add_argument("directory",
+                        metavar="<file directory>",
                         type=str,
                         nargs=1,
                         help="root directory of files"
@@ -232,8 +244,7 @@ if __name__ == "__main__":
     if args.out:
         output = args.out[0]
 
-    with open(args.tree[0], 'r') as f:
-        dirtree = json.load(f)
+    dirtree = traverseDirectory(args.directory[0])
 
-    rootdir = Directory(dirtree[0], baseurl, curpath, ignoredextension, output)
+    rootdir = Directory(dirtree, baseurl, curpath, ignoredextension, output)
     rootdir.write()

--- a/apindex.py
+++ b/apindex.py
@@ -93,7 +93,7 @@ class File():
         return self.file["name"]
 
     def getPath(self):
-        if self.isDirectory() or [True if self.getFileName().endswith(ext) else False for ext in self.ignoredextension]:
+        if self.baseurl.startswith(".") or self.isDirectory() or [True if self.getFileName().endswith(ext) else False for ext in self.ignoredextension].count(True):
             return f"{self.curpath}/{self.getFileName()}"
         else:
             return f"{self.baseurl}/{self.getFileName()}"


### PR DESCRIPTION
This will remove the tree requirement from apindex. All the user has to do is specify a directory instead of the output of `tree -Js` to generate a file listing.